### PR TITLE
add job dashboard "bullboard" to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,21 @@ services:
       - '6379:6379'
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
+    volumes:
+      - redis_data:/data
+
+  # Note this container must be restarted to detect newly created queues
+  # Repo: https://github.com/felixmosh/bull-board
+  bullboard: # dashboard for the job queue
+    container_name: cdd-bullboard
+    image: deadly0/bull-board # Note: unofficial image
+    restart: unless-stopped
+    ports:
+      - 3334:3000
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    environment:
+      REDIS_HOST: host.docker.internal
 
   alice:
       image: ${CHAIN_IMAGE}
@@ -24,3 +39,6 @@ services:
         [
           '--alice --chain dev',
         ]
+
+volumes:
+  redis_data:


### PR DESCRIPTION
Adds a bullboard image to dev so we can get used to it in dev. For production we probably should build from source and deploy that instead.

https://github.com/felixmosh/bull-board

Demo video:

https://user-images.githubusercontent.com/86971143/224833856-624a2e07-4fd6-4fa9-870e-863294308e74.mov

(I need to look into adding logs to the bull job. It would be nice to write them there instead of needing to correlate application logs)