### PR TITLE
add metrics module to expose netki code count

### DIFF
--- a/.env.sample.server
+++ b/.env.sample.server
@@ -1,8 +1,9 @@
 # An example of all the env variables the server uses
 
-APP_PORT=3333                    # the port the app will listen on
-APP_ROUTE_PREFIX=/api            # a prefix for all routes
-APP_HEALTH_IPS=172.16.0.0/16,::1 # CSV list of IPs able to access health checks
+APP_PORT=3333                     # the port the app will listen on
+APP_ROUTE_PREFIX=/api             # a prefix for all routes
+APP_HEALTH_IPS=172.16.0.0/16,::1  # CSV list of IPs able to access health checks
+APP_METRICS_IPS=172.16.0.0/16,::1 # CSV list of IPs able to access health checks
 
 MESH_NODE_URL=wss://testnet-rpc.polymesh.live/ # polymesh ws url
 

--- a/apps/cdd-backend/src/app-redis/app-redis.service.spec.ts
+++ b/apps/cdd-backend/src/app-redis/app-redis.service.spec.ts
@@ -66,6 +66,7 @@ describe('AppRedisService', () => {
 
   describe('netkiCodes', () => {
     const exampleCode = { code: 'someCode' } as unknown as NetkiAccessLinkModel;
+
     it('should add codes', async () => {
       redis.scard.mockResolvedValue(1);
       redis.sadd.mockResolvedValue(1);
@@ -76,6 +77,16 @@ describe('AppRedisService', () => {
         JSON.stringify(exampleCode),
       ]);
       expect(result).toEqual({ added: 1, total: 1 });
+    });
+  });
+
+  describe('availableNetkiCodeCount', () => {
+    it('should return the count from scard', async () => {
+      redis.scard.mockResolvedValue(7);
+
+      const result = await service.availableNetkiCodeCount();
+
+      expect(result).toEqual(7);
     });
   });
 

--- a/apps/cdd-backend/src/app-redis/app-redis.service.ts
+++ b/apps/cdd-backend/src/app-redis/app-redis.service.ts
@@ -70,14 +70,14 @@ export class AppRedisService {
     return JSON.parse(rawCode);
   }
 
-  async allocateCode(code: string, address: string): Promise<void> {
+  async allocateNetkiCode(code: string, address: string): Promise<void> {
     await this.setNetkiCodeToAddress(code, address);
 
     const key = netkiAddressPrefixer(code);
     await this.redis.set(key, address);
   }
 
-  async getAllocatedCodes(): Promise<Set<string>> {
+  async getAllocatedNetkiCodes(): Promise<Set<string>> {
     const allocatedCodes = await this.redis.keys(
       `${netkiAllocatedCodePrefix}*`
     );
@@ -85,6 +85,10 @@ export class AppRedisService {
     return new Set(
       allocatedCodes.map((code) => code.replace(netkiAllocatedCodePrefix, ''))
     );
+  }
+
+  async availableNetkiCodeCount(): Promise<number> {
+    return await this.redis.scard(netkiAvailableCodesPrefix);
   }
 
   async isHealthy(): Promise<boolean> {

--- a/apps/cdd-backend/src/config/server.ts
+++ b/apps/cdd-backend/src/config/server.ts
@@ -22,6 +22,7 @@ const configZ = z
           .default(['localhost:4200'])
           .describe('CSV list of allowed CORS domains'),
         healthAllowedIps: allowedIpsZ,
+        metricsAllowedIps: allowedIpsZ,
       })
       .describe('server related config'),
 
@@ -102,6 +103,9 @@ export const serverEnvConfig = (): ServerConfig => {
         (domain) => domain.trim()
       ),
       healthAllowedIps: process.env.APP_HEALTH_IPS?.split(',').map((ip) =>
+        ip.trim()
+      ),
+      metricsAllowedIps: process.env.APP_METRICS_IPS?.split(',').map((ip) =>
         ip.trim()
       ),
     },

--- a/apps/cdd-backend/src/entry/server.module.ts
+++ b/apps/cdd-backend/src/entry/server.module.ts
@@ -9,6 +9,7 @@ import { serverEnvConfig } from '../config/server';
 import { loggerEnvConfig } from '../config/logger';
 import { InfoModule } from '../info/info.module';
 import { HealthModule } from '../health/health.module';
+import { MetricsModule } from '../metrics/metrics.module';
 
 /**
  * Module for initializing the app in "server" mode
@@ -22,6 +23,7 @@ import { HealthModule } from '../health/health.module';
     CddModule,
     InfoModule,
     HealthModule,
+    MetricsModule,
   ],
   providers: [
     {

--- a/apps/cdd-backend/src/metrics/metrics.controller.spec.ts
+++ b/apps/cdd-backend/src/metrics/metrics.controller.spec.ts
@@ -1,0 +1,40 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger } from 'winston';
+import { ALLOWED_IPS_PROVIDER } from '../common/ip-filter.guard';
+import { MetricsController } from './metrics.controller';
+import { MetricsService } from './metrics.service';
+
+describe('MetricsController', () => {
+  let controller: MetricsController;
+  let mockService: DeepMocked<MetricsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MetricsController],
+      providers: [
+        { provide: MetricsService, useValue: createMock<MetricsService>() },
+        { provide: ALLOWED_IPS_PROVIDER, useValue: [] },
+        { provide: WINSTON_MODULE_PROVIDER, useValue: createMock<Logger>() },
+      ],
+    }).compile();
+
+    controller = module.get<MetricsController>(MetricsController);
+    mockService = module.get<typeof mockService>(MetricsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('netki-codes', () => {
+    it('should call and return the service result', async () => {
+      mockService.getNetkiAvailableCodeCount.mockResolvedValue({ count: 7 });
+
+      const result = await controller.getNetkiCodeCount();
+
+      expect(result).toEqual({ count: 7 });
+    });
+  });
+});

--- a/apps/cdd-backend/src/metrics/metrics.controller.ts
+++ b/apps/cdd-backend/src/metrics/metrics.controller.ts
@@ -1,0 +1,22 @@
+import { NetkiCodeCountResponse } from '@cdd-onboarding/cdd-types';
+import { Controller, Get, HttpStatus, UseGuards } from '@nestjs/common';
+import { ApiResponse, ApiTags } from '@nestjs/swagger';
+import { IpFilterGuard } from '../common/ip-filter.guard';
+import { MetricsService } from './metrics.service';
+
+@Controller('metrics')
+@ApiTags('metrics')
+@UseGuards(IpFilterGuard)
+export class MetricsController {
+  constructor(private readonly metricsService: MetricsService) {}
+
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'available netki codes',
+    type: NetkiCodeCountResponse,
+  })
+  @Get('/netki-codes')
+  public async getNetkiCodeCount(): Promise<NetkiCodeCountResponse> {
+    return this.metricsService.getNetkiAvailableCodeCount();
+  }
+}

--- a/apps/cdd-backend/src/metrics/metrics.module.ts
+++ b/apps/cdd-backend/src/metrics/metrics.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { AppRedisModule } from '../app-redis/app-redis.module';
+import { ALLOWED_IPS_PROVIDER } from '../common/ip-filter.guard';
+import { MetricsController } from './metrics.controller';
+import { MetricsService } from './metrics.service';
+
+@Module({
+  imports: [AppRedisModule, ConfigModule],
+  controllers: [MetricsController],
+  providers: [
+    MetricsService,
+    {
+      provide: ALLOWED_IPS_PROVIDER,
+      useFactory: (config: ConfigService) =>
+        config.getOrThrow<string[]>('server.metricsAllowedIps'),
+      inject: [ConfigService],
+    },
+  ],
+})
+export class MetricsModule {}

--- a/apps/cdd-backend/src/metrics/metrics.service.spec.ts
+++ b/apps/cdd-backend/src/metrics/metrics.service.spec.ts
@@ -1,0 +1,38 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppRedisService } from '../app-redis/app-redis.service';
+import { MetricsService } from './metrics.service';
+
+describe('MetricsService', () => {
+  let service: MetricsService;
+  let mockRedis: DeepMocked<AppRedisService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MetricsService,
+        {
+          provide: AppRedisService,
+          useValue: createMock<AppRedisService>(),
+        },
+      ],
+    }).compile();
+
+    service = module.get<MetricsService>(MetricsService);
+    mockRedis = module.get<typeof mockRedis>(AppRedisService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getNetkiAvailableCodeCount', () => {
+    it('should call and return the count from redis', async () => {
+      mockRedis.availableNetkiCodeCount.mockResolvedValue(7);
+
+      const result = await service.getNetkiAvailableCodeCount();
+
+      expect(result).toEqual({ count: 7 });
+    });
+  });
+});

--- a/apps/cdd-backend/src/metrics/metrics.service.ts
+++ b/apps/cdd-backend/src/metrics/metrics.service.ts
@@ -1,0 +1,14 @@
+import { NetkiCodeCountResponse } from '@cdd-onboarding/cdd-types';
+import { Injectable } from '@nestjs/common';
+import { AppRedisService } from '../app-redis/app-redis.service';
+
+@Injectable()
+export class MetricsService {
+  constructor(private readonly redis: AppRedisService) {}
+
+  public async getNetkiAvailableCodeCount(): Promise<NetkiCodeCountResponse> {
+    const count = await this.redis.availableNetkiCodeCount();
+
+    return { count };
+  }
+}

--- a/apps/cdd-backend/src/netki/netki.service.spec.ts
+++ b/apps/cdd-backend/src/netki/netki.service.spec.ts
@@ -114,7 +114,7 @@ describe('NetkiService', () => {
         .spyOn(mockHttp, 'post')
         .mockImplementation(() => of(mockAccessResponse));
 
-      mockRedis.getAllocatedCodes.mockResolvedValue(new Set());
+      mockRedis.getAllocatedNetkiCodes.mockResolvedValue(new Set());
       mockRedis.pushNetkiCodes.mockResolvedValue({ added: 1, total: 3 });
 
       const result = await service.fetchAccessCodes();

--- a/apps/cdd-backend/src/netki/netki.service.ts
+++ b/apps/cdd-backend/src/netki/netki.service.ts
@@ -58,7 +58,7 @@ export class NetkiService {
 
     const url = `${this.linkBaseUrl}?service_code=${accessCode.code}&applicationId=${address}`;
 
-    await this.redis.allocateCode(accessCode.code, address);
+    await this.redis.allocateNetkiCode(accessCode.code, address);
 
     return {
       ...accessCode,
@@ -103,7 +103,7 @@ export class NetkiService {
       throw new InternalServerErrorException();
     }
 
-    const allocatedCodes = await this.redis.getAllocatedCodes();
+    const allocatedCodes = await this.redis.getAllocatedNetkiCodes();
 
     const newLinks = codeResponse?.data?.results
       .filter(

--- a/libs/cdd-types/src/index.ts
+++ b/libs/cdd-types/src/index.ts
@@ -4,3 +4,4 @@ export * from './lib/address-applications';
 export * from './lib/health';
 export * from './lib/utils';
 export * from './lib/email';
+export * from './lib/metrics';

--- a/libs/cdd-types/src/lib/metrics.ts
+++ b/libs/cdd-types/src/lib/metrics.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class NetkiCodeCountResponse {
+  @ApiProperty({
+    description: 'number of available netki codes',
+  })
+  readonly count: number;
+
+  constructor(count: number) {
+    this.count = count;
+  }
+}


### PR DESCRIPTION
Having a metrics module lets us integrate with the existing graphana infrastructure to better so we can have alerts on these running low.

To recover from low netki codes we need to reach out to netki so it should be OK as a manual process. A set of codes should last us for a while.

[DA-534](https://polymesh.atlassian.net/browse/DA-534)

[DA-534]: https://polymesh.atlassian.net/browse/DA-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ