### PR TITLE
fixes `Dockerfile` expecting nested path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,7 +124,6 @@ node {
                 },
                 worker: {
                     sh (label: 'Build `worker.Dockerfile`',
-                        script: 'docker build -f docker/worker.Dockerfile -t "${CONTAINER_REGISTRY}/${CONTAINER_IMAGE_PREFIX}-worker:${GIT_COMMIT}" .')
                         script: 'cd docker/ && docker build -f worker.Dockerfile -t "${CONTAINER_REGISTRY}/${CONTAINER_IMAGE_PREFIX}-worker:${GIT_COMMIT}" .. && cd ../')
                 },
                 ui: {


### PR DESCRIPTION
- fixes `env.CONTAINER_IMAGE_PREFIX`
- fixes paths for `Dockerfile` expecting to be built from within nested path instead of root of project; resolves `Step 7/7 : COPY .. . : COPY failed: forbidden path outside the build context: .. ()`