### PR TITLE
quinn/docker-fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,5 +6,7 @@ dist
 .env
 .gitignore
 .dockerignore
+**/*Dockerfile
+docker/build.sh
 .github/
 Jenkinsfile

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,21 +114,29 @@ node {
 
             stage('Build (stage 1)') {
                 sh (label: 'Build `builder.Dockerfile`',
-                    script: 'cd docker/ && docker build -f builder.Dockerfile -t "${CONTAINER_REGISTRY}/${CONTAINER_IMAGE_PREFIX}-builder:${GIT_COMMIT}" .. && cd ../')
+                    script: '''#!/bin/bash
+                            docker build -f docker/builder.Dockerfile -t "mesh-cdd-builder:${GIT_COMMIT}" .
+                            ''')
             }
 
             stage('Build (stage 2)') {
                 parallel server: {
                     sh (label: 'Build `server.Dockerfile`',
-                        script: 'cd docker/ && docker build -f server.Dockerfile -t "${CONTAINER_REGISTRY}/${CONTAINER_IMAGE_PREFIX}-server:${GIT_COMMIT}" .. && cd ../')
+                        script: '''#!/bin/bash
+                                docker build --build-arg "BUILDER_CONTAINER_TAG=${GIT_COMMIT}" -f docker/server.Dockerfile -t "${CONTAINER_REGISTRY}/${CONTAINER_IMAGE_PREFIX}-server:${GIT_COMMIT}" .
+                                ''')
                 },
                 worker: {
                     sh (label: 'Build `worker.Dockerfile`',
-                        script: 'cd docker/ && docker build -f worker.Dockerfile -t "${CONTAINER_REGISTRY}/${CONTAINER_IMAGE_PREFIX}-worker:${GIT_COMMIT}" .. && cd ../')
+                        script: '''#!/bin/bash
+                                docker build --build-arg "BUILDER_CONTAINER_TAG=${GIT_COMMIT}" -f docker/worker.Dockerfile -t "${CONTAINER_REGISTRY}/${CONTAINER_IMAGE_PREFIX}-worker:${GIT_COMMIT}" .
+                                ''')
                 },
                 ui: {
                     sh (label: 'Build `web.Dockerfile`',
-                        script: 'cd docker/ && docker build -f web.Dockerfile -t "${CONTAINER_REGISTRY}/${CONTAINER_IMAGE_PREFIX}-ui:${GIT_COMMIT}" .. && cd ../')
+                        script: '''#!/bin/bash
+                                docker build --build-arg "BUILDER_CONTAINER_TAG=${GIT_COMMIT}" -f docker/web.Dockerfile -t "${CONTAINER_REGISTRY}/${CONTAINER_IMAGE_PREFIX}-ui:${GIT_COMMIT}" .
+                                ''')
                 }
             }
 

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -12,4 +12,4 @@ RUN yarn global add nx
 COPY package.json yarn.lock ./
 
 RUN ["yarn", "install"]
-COPY .. .
+COPY . .

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -1,9 +1,17 @@
-FROM mesh-cdd-builder AS builder
+ARG BUILDER_CONTAINER_TAG=latest
+
+FROM mesh-cdd-builder:${BUILDER_CONTAINER_TAG} AS builder
 
 RUN nx dep-graph --file dep-graph.json
 RUN nx build cdd-backend --configuration=production
 
 FROM node:lts-alpine3.17
+
+# `nx` npm package dependencies:
+RUN apk add python3 \
+            make \
+            cmake \
+            g++
 
 RUN addgroup runner && adduser --uid 1001 -G runner -D --shell /bin/false runner
 

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -1,4 +1,6 @@
-FROM mesh-cdd-builder AS builder
+ARG BUILDER_CONTAINER_TAG=latest
+
+FROM mesh-cdd-builder:${BUILDER_CONTAINER_TAG} AS builder
 
 ENV NX_API_URL='__NX_API_URL__'
 ENV NX_MESH_NETWORK='__NX_MESH_NETWORK__'

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -1,9 +1,17 @@
-FROM mesh-cdd-builder AS builder
+ARG BUILDER_CONTAINER_TAG=latest
+
+FROM mesh-cdd-builder:${BUILDER_CONTAINER_TAG} AS builder
 
 RUN nx dep-graph --file dep-graph.json
 RUN nx build cdd-backend:buildWorker --configuration=production
 
 FROM node:lts-alpine3.17
+
+# `nx` npm package dependencies:
+RUN apk add python3 \
+            make \
+            cmake \
+            g++
 
 RUN addgroup runner && adduser --uid 1001 -G runner -D --shell /bin/false runner
 


### PR DESCRIPTION
- adds `**/*Dockerfile` and `docker/build.sh` to `.dockerignore`
- adds `nx` npm package dependencies; fixes `yarn install` related issues on `ARM64`
- parameterizes builder container tag, for specifying explicit `FROM mesh-cdd-builder:${BUILDER_CONTAINER_TAG} AS builder` at build time
- normalizes paths to use repository root path as docker build context