### PR TITLE
use browser signer to only authorize official wallet

### DIFF
--- a/apps/cdd-frontend/src/components/AddressPicker.tsx
+++ b/apps/cdd-frontend/src/components/AddressPicker.tsx
@@ -25,7 +25,7 @@ import {
 import { BiImport, BiChevronDown } from 'react-icons/bi';
 import { addressZ } from '@cdd-onboarding/cdd-types/utils';
 
-import usePolyWallet from '../hooks/usePollyWallet';
+import useBrowserSigningManager from '../hooks/usePollyWallet';
 import config, { NETWORK_NAMES } from '../config/constants';
 
 const schema = z.object({
@@ -62,7 +62,7 @@ const AddressPicker: React.FC<AddressPickerProps> = ({
     defaultValues: { address },
   });
   const { connectToWallet, allAddresses, isCorrectNetwork, isWalletAvailable } =
-    usePolyWallet({ network: config.NETWORK });
+    useBrowserSigningManager({ network: config.NETWORK });
 
   const onSetAddress = (address: string) => {
     setValue('address', address);

--- a/apps/cdd-frontend/src/pages/Verification/steps/EnterAddress.tsx
+++ b/apps/cdd-frontend/src/pages/Verification/steps/EnterAddress.tsx
@@ -32,7 +32,7 @@ import {
 } from '@polymeshassociation/polymesh-theme/ui/organisms';
 
 import useVerifyAddressMutation from '../../../hooks/useVerifyAddressMutation';
-import usePolyWallet from '../../..//hooks/usePollyWallet';
+import useBrowserSigningManager from '../../..//hooks/usePollyWallet';
 import { VerificationState } from './index.d';
 import config, { NETWORK_NAMES } from '../../../config/constants';
 
@@ -71,7 +71,7 @@ export const EnterAddress: React.FC<EnterAddressProps> = ({
   const { mutate, isLoading, isSuccess, isError, error, data } =
     useVerifyAddressMutation();
   const { connectToWallet, allAddresses, isCorrectNetwork, isWalletAvailable } =
-    usePolyWallet({ network: config.NETWORK });
+    useBrowserSigningManager({ network: config.NETWORK });
   const { message } = (error as AxiosError) || {};
   const onSubmit = ({ address, hCaptcha }: VerifyAddressPayload) => {
     setState({ address });

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@opentelemetry/resources": "^1.9.1",
     "@opentelemetry/sdk-node": "^0.35.1",
     "@opentelemetry/semantic-conventions": "^1.9.1",
-    "@polkadot/extension-dapp": "0.44.9 ",
+    "@polymeshassociation/browser-extension-signing-manager": "^1.4.0",
     "@polymeshassociation/hashicorp-vault-signing-manager": "2.1.0",
     "@polymeshassociation/local-signing-manager": "2.1.0",
     "@polymeshassociation/polymesh-sdk": "20.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4108,7 +4108,7 @@
     eventemitter3 "^5.0.0"
     rxjs "^7.8.0"
 
-"@polkadot/extension-dapp@0.44.9 ":
+"@polkadot/extension-dapp@^0.44.7":
   version "0.44.9"
   resolved "https://registry.yarnpkg.com/@polkadot/extension-dapp/-/extension-dapp-0.44.9.tgz#0ed8ba7442e36b1dde950c90767a07b13eb2cb81"
   integrity sha512-xYY9bg4y2YW1ORWTflrPBypYueCpzajlYsU1CWuPP9fzKsdfd97wwa+dIYYvLbJy7tcivC+uIT3BpaFaJn2mXg==
@@ -4393,6 +4393,16 @@
     "@types/websocket" "^1.0.5"
     websocket "^1.0.34"
 
+"@polymeshassociation/browser-extension-signing-manager@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@polymeshassociation/browser-extension-signing-manager/-/browser-extension-signing-manager-1.4.0.tgz#e67f1566c0c977ab40c70e33b5ea30802c452e57"
+  integrity sha512-Wqx8CGhbhKAQbAVQtsp/42NZGwToR41SFVbS2dTN1fm41QB0jQrbJTSXUGlKBH6fEMHIIezsVXsmrbL2hfS+uw==
+  dependencies:
+    "@polkadot/extension-dapp" "^0.44.7"
+    "@polkadot/util" "^10.4.2"
+    "@polkadot/util-crypto" "^10.4.2"
+    "@polymeshassociation/signing-manager-types" "^2.0.0"
+
 "@polymeshassociation/hashicorp-vault-signing-manager@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@polymeshassociation/hashicorp-vault-signing-manager/-/hashicorp-vault-signing-manager-2.1.0.tgz#1fb400a9d0887afc3ce71781aa6b87cd1fbd2663"
@@ -4444,7 +4454,7 @@
   resolved "https://registry.yarnpkg.com/@polymeshassociation/signing-manager-types/-/signing-manager-types-1.2.4.tgz#5a6f5570c203e47a2a6c690edfe320fce54a383b"
   integrity sha512-B01juQe5h75LIV2KEwxhyaSGLKWevJUlEi4x1+5WI5YEL3BZGkV5an7eqFh0WW5jTuHGELw6kHq3rt6pEFTByw==
 
-"@polymeshassociation/signing-manager-types@^2.1.0":
+"@polymeshassociation/signing-manager-types@^2.0.0", "@polymeshassociation/signing-manager-types@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@polymeshassociation/signing-manager-types/-/signing-manager-types-2.1.0.tgz#c4c6e27e93d3d98de5c28a92862bcab7fb527a6c"
   integrity sha512-UJaaFuHeHtduN42bU5GUhJ7JgExhWvcF5751jHxGg7Gj4xjQyiaNvpQsejYeOlUoALnZ1McmB3nPrbm03TeNKA==


### PR DESCRIPTION
There is a fair amount of code being test in browser signer manager that handles authorizing only the official wallet.

[DA-789](https://polymesh.atlassian.net/browse/DA-789)

[DA-789]: https://polymesh.atlassian.net/browse/DA-789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ