### PR TITLE
fix: `apple-touch-icon.png` is within `/assets/img/`

### DIFF
--- a/apps/cdd-frontend/src/index.html
+++ b/apps/cdd-frontend/src/index.html
@@ -6,7 +6,7 @@
     <base href="/" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/img/apple-touch-icon.png" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link
       rel="icon"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,8 +1,19 @@
 server {
-    listen 80;
+    listen 0.0.0.0:80;
+
+    server_name _;
+
+    root /usr/share/nginx/html;
+
+    index index.html;
+
+    server_tokens off;
+
+    location /assets/ {
+        try_files $uri =404;
+    }
 
     location / {
-        root /usr/share/nginx/html;
-        try_files $uri /index.html;
+        try_files $uri $uri/ /index.html;
     }
 }

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -10,6 +10,10 @@ FROM nginx:stable-alpine3.17
 ################################################################
 
 COPY --chown=root:root docker/replace-env-var-placeholders.sh /usr/local/bin/
+COPY --chown=root:root docker/nginx.conf /etc/nginx/conf.d/default.conf
+
+################################################################
+
 COPY --from=builder --chown=root:root /app/env.var.list /srv/
 COPY --from=builder --chown=root:root /app/builder/dist/apps/cdd-frontend /usr/share/nginx/html
 


### PR DESCRIPTION
fix: `apple-touch-icon.png` is within `/assets/img/`; enables ability to properly 404 on missing assets (unfortunately only within `/assets/`, due to single page catchall), and restores `/index.html` catchall