### PR TITLE
update address not found copy on netki result

### DIFF
--- a/apps/cdd-frontend/src/components/ResultPage/steps/AddressStep.tsx
+++ b/apps/cdd-frontend/src/components/ResultPage/steps/AddressStep.tsx
@@ -54,6 +54,7 @@ const AddressStep: React.FC<Pick<StepTemplateProps, 'index'>> = ({ index }) => {
   if (!address && localStatus !== VerificationStatus.PROCESSING) {
     return (
       <StepTemplate title="Please select your address" index={index}>
+        <strong>Note: </strong>Alternatively check on the device you began the onboarding process with. This usually happens when starting on a PC and completing the onboarding process using a phone.
         <AddressPicker onSubmit={({ address }) => setAddress(address)} />
       </StepTemplate>
     );


### PR DESCRIPTION
<img width="732" alt="netki-copy-change" src="https://github.com/PolymeshAssociation/cdd-onboarding/assets/86971143/6af61d8a-6510-44b8-80bd-c7f629a221d1">

Its takes up a few lines because the container has a 300px width set on it, but I don't really want to change that since its likely there for a reason.

[DA-829](https://polymesh.atlassian.net/browse/DA-829)

[DA-829]: https://polymesh.atlassian.net/browse/DA-829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ