### PR TITLE
improve pending application copy

### DIFF
--- a/apps/cdd-frontend/src/components/AddressPicker.tsx
+++ b/apps/cdd-frontend/src/components/AddressPicker.tsx
@@ -178,7 +178,7 @@ const AddressPicker: React.FC<AddressPickerProps> = ({
           )}
           {!isWalletAvailable && (
             <FormHelperText>
-              Your don't have a Polymesh Wallet connected. Approve the request
+              You don't have a Polymesh Wallet connected. Approve the request
               to connect to Polymesh wallet or get from{' '}
               <Link
                 color="navy"

--- a/apps/cdd-frontend/src/components/ResultPage/VerificationMessage.tsx
+++ b/apps/cdd-frontend/src/components/ResultPage/VerificationMessage.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   chakra,
   Heading,
+  Link,
   shouldForwardProp,
   Text,
 } from '@chakra-ui/react';
@@ -75,9 +76,14 @@ const VerificationMessage: React.FC = () => {
                 style={{ width: 32, height: 32 }}
               />
             </Heading>
-            <Text fontSize="xl" textAlign="center">
-              Identity should be created soon.
+            <Text fontSize="xl" textAlign="center" mb="2rem">
+              Identity should be created soon
             </Text>
+
+            <Text textAlign="center">
+              Bookmark <Link href={window.location.href}>this page</Link> and return later to check your onboarding status
+            </Text>
+
           </MotionStack>
         </AnimatePresence>
       )}

--- a/apps/cdd-frontend/src/components/ResultPage/steps/ChainStatus.tsx
+++ b/apps/cdd-frontend/src/components/ResultPage/steps/ChainStatus.tsx
@@ -57,7 +57,7 @@ const ChainStatus: React.FC<Pick<StepTemplateProps, 'index'>> = ({ index }) => {
         <StepTemplate title="Identity not created" index={index}>
           <Text mb={2} as="span">
             Mock identity not yet created. It is expected to take a few minutes
-            at most. Try refreshing the page to check again
+            at most. Try refreshing the page to check again.
           </Text>
 
           <Text mb={2} as="span">

--- a/apps/cdd-frontend/src/pages/Verification/steps/EnterAddress.tsx
+++ b/apps/cdd-frontend/src/pages/Verification/steps/EnterAddress.tsx
@@ -295,7 +295,7 @@ export const EnterAddress: React.FC<EnterAddressProps> = ({
           )}
           {!isWalletAvailable && (
             <FormHelperText>
-              Your don't have a Polymesh Wallet connected. Approve the request
+              You don't have a Polymesh Wallet connected. Approve the request
               to connect to Polymesh wallet or get from{' '}
               <Link
                 color="navy"


### PR DESCRIPTION
Hopefully it helps people realize they need to save the page URL

[DA-1027](https://polymesh.atlassian.net/browse/DA-1027)

I tried a few different ways, but the page URL will have the provider + the address, so it doesn't look good when rendered onto the page.

[DA-1027]: https://polymesh.atlassian.net/browse/DA-1027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ