### PR TITLE
add /metrics/job-stats endpoint

### DIFF
--- a/apps/cdd-backend/src/metrics/metrics.controller.spec.ts
+++ b/apps/cdd-backend/src/metrics/metrics.controller.spec.ts
@@ -37,4 +37,26 @@ describe('MetricsController', () => {
       expect(result).toEqual({ count: 7 });
     });
   });
+
+  describe('job stats', () => {
+    it('should call and return the service result', async () => {
+      mockService.getJobQueueStats.mockResolvedValue({
+        active: 1,
+        completed: 2,
+        failed: 3,
+        waiting: 4,
+        oldestSeconds: 5,
+      });
+
+      const result = await controller.getJobQueueStats();
+
+      expect(result).toEqual({
+        active: 1,
+        completed: 2,
+        failed: 3,
+        waiting: 4,
+        oldestSeconds: 5,
+      });
+    });
+  });
 });

--- a/apps/cdd-backend/src/metrics/metrics.controller.ts
+++ b/apps/cdd-backend/src/metrics/metrics.controller.ts
@@ -1,8 +1,11 @@
-import { NetkiCodeCountResponse } from '@cdd-onboarding/cdd-types';
+import {
+  JobQueueStatsResponse,
+  NetkiCodeCountResponse,
+} from '@cdd-onboarding/cdd-types';
 import { Controller, Get, HttpStatus, UseGuards } from '@nestjs/common';
 import { ApiResponse, ApiTags } from '@nestjs/swagger';
-import { IpFilterGuard } from '../common/ip-filter.guard';
 import { MetricsService } from './metrics.service';
+import { IpFilterGuard } from '../common/ip-filter.guard';
 
 @Controller('metrics')
 @ApiTags('metrics')
@@ -18,5 +21,15 @@ export class MetricsController {
   @Get('/netki-codes')
   public async getNetkiCodeCount(): Promise<NetkiCodeCountResponse> {
     return this.metricsService.getNetkiAvailableCodeCount();
+  }
+
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'job queue statistics',
+    type: JobQueueStatsResponse,
+  })
+  @Get('/job-stats')
+  public async getJobQueueStats(): Promise<JobQueueStatsResponse> {
+    return this.metricsService.getJobQueueStats();
   }
 }

--- a/apps/cdd-backend/src/metrics/metrics.module.ts
+++ b/apps/cdd-backend/src/metrics/metrics.module.ts
@@ -4,9 +4,10 @@ import { AppRedisModule } from '../app-redis/app-redis.module';
 import { ALLOWED_IPS_PROVIDER } from '../common/ip-filter.guard';
 import { MetricsController } from './metrics.controller';
 import { MetricsService } from './metrics.service';
+import { BullModule } from '@nestjs/bull';
 
 @Module({
-  imports: [AppRedisModule, ConfigModule],
+  imports: [AppRedisModule, ConfigModule, BullModule.registerQueue({})],
   controllers: [MetricsController],
   providers: [
     MetricsService,

--- a/apps/cdd-backend/src/metrics/metrics.service.spec.ts
+++ b/apps/cdd-backend/src/metrics/metrics.service.spec.ts
@@ -2,10 +2,13 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppRedisService } from '../app-redis/app-redis.service';
 import { MetricsService } from './metrics.service';
+import { getQueueToken } from '@nestjs/bull';
+import { Job, Queue } from 'bull';
 
 describe('MetricsService', () => {
   let service: MetricsService;
   let mockRedis: DeepMocked<AppRedisService>;
+  let mockQueue: DeepMocked<Queue>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -15,11 +18,16 @@ describe('MetricsService', () => {
           provide: AppRedisService,
           useValue: createMock<AppRedisService>(),
         },
+        {
+          provide: getQueueToken(),
+          useValue: createMock<Queue>(),
+        },
       ],
     }).compile();
 
     service = module.get<MetricsService>(MetricsService);
     mockRedis = module.get<typeof mockRedis>(AppRedisService);
+    mockQueue = module.get<typeof mockQueue>(getQueueToken(''));
   });
 
   it('should be defined', () => {
@@ -33,6 +41,30 @@ describe('MetricsService', () => {
       const result = await service.getNetkiAvailableCodeCount();
 
       expect(result).toEqual({ count: 7 });
+    });
+  });
+
+  describe('getNetkiAvailableCodeCount', () => {
+    it('should call and return the count from redis', async () => {
+      mockQueue.getActiveCount.mockResolvedValue(1);
+      mockQueue.getCompletedCount.mockResolvedValue(2);
+      mockQueue.getFailedCount.mockResolvedValue(3);
+      mockQueue.getWaitingCount.mockResolvedValue(4);
+      mockQueue.getWaiting.mockResolvedValue([
+        {
+          timestamp: 1,
+        } as Job,
+      ]);
+
+      const result = await service.getJobQueueStats();
+
+      expect(result).toEqual({
+        active: 1,
+        completed: 2,
+        failed: 3,
+        waiting: 4,
+        oldestSeconds: expect.any(Number),
+      });
     });
   });
 });

--- a/apps/cdd-backend/src/metrics/metrics.service.ts
+++ b/apps/cdd-backend/src/metrics/metrics.service.ts
@@ -1,14 +1,47 @@
-import { NetkiCodeCountResponse } from '@cdd-onboarding/cdd-types';
+import {
+  JobQueueStatsResponse,
+  NetkiCodeCountResponse,
+} from '@cdd-onboarding/cdd-types';
 import { Injectable } from '@nestjs/common';
 import { AppRedisService } from '../app-redis/app-redis.service';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
 
 @Injectable()
 export class MetricsService {
-  constructor(private readonly redis: AppRedisService) {}
+  constructor(
+    private readonly redis: AppRedisService,
+    @InjectQueue('') private readonly queue: Queue
+  ) {}
 
   public async getNetkiAvailableCodeCount(): Promise<NetkiCodeCountResponse> {
     const count = await this.redis.availableNetkiCodeCount();
 
     return { count };
+  }
+
+  public async getJobQueueStats(): Promise<JobQueueStatsResponse> {
+    const [active, completed, failed, waiting, [oldestJob]] = await Promise.all(
+      [
+        this.queue.getActiveCount(),
+        this.queue.getCompletedCount(),
+        this.queue.getFailedCount(),
+        this.queue.getWaitingCount(),
+        this.queue.getWaiting(0, 0),
+      ]
+    );
+
+    let oldestSeconds = 0;
+    if (oldestJob) {
+      oldestSeconds = Math.floor((Date.now() - oldestJob.timestamp) / 1000);
+    }
+
+    return {
+      active,
+      completed,
+      failed,
+      waiting,
+      oldestSeconds,
+    };
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
          - redis-data:/data
 
     mesh:
-        image: ${CHAIN_IMAGE:-polymeshassociation/polymesh:5.4.0-develop-debian}
+        image: ${CHAIN_IMAGE:-polymeshassociation/polymesh:6.0.0-testnet-debian}
         init: true # Faster shutdown when enabled
         restart: unless-stopped
         ports: # expose ports to localhost

--- a/libs/cdd-types/src/lib/metrics.ts
+++ b/libs/cdd-types/src/lib/metrics.ts
@@ -10,3 +10,44 @@ export class NetkiCodeCountResponse {
     this.count = count;
   }
 }
+
+export class JobQueueStatsResponse {
+  @ApiProperty({
+    description: 'number of active jobs',
+  })
+  readonly active: number;
+
+  @ApiProperty({
+    description: 'number of completed jobs',
+  })
+  readonly completed: number;
+
+  @ApiProperty({
+    description: 'number of failed jobs',
+  })
+  readonly failed: number;
+
+  @ApiProperty({
+    description: 'number of waiting jobs',
+  })
+  readonly waiting: number;
+
+  @ApiProperty({
+    description: 'number of seconds the oldest job has been waiting',
+  })
+  readonly oldestSeconds: number;
+
+  constructor({
+    active,
+    completed,
+    failed,
+    waiting,
+    oldestSeconds,
+  }: JobQueueStatsResponse) {
+    this.active = active;
+    this.completed = completed;
+    this.failed = failed;
+    this.waiting = waiting;
+    this.oldestSeconds = oldestSeconds;
+  }
+}


### PR DESCRIPTION
Adds endpoint to report job counts + time of the oldest job waiting in seconds