### PR TITLE
cast netki code to lower

### DIFF
--- a/apps/cdd-backend/src/cdd-worker/cdd.processor.spec.ts
+++ b/apps/cdd-backend/src/cdd-worker/cdd.processor.spec.ts
@@ -177,6 +177,16 @@ describe('cddProcessor', () => {
           expect(mockRedis.clearApplications).toHaveBeenCalledWith(address);
         });
 
+        it('should convert client_guid to lower case', async () => {
+          const uppercaseIdJob = { ...mockNetkiCompletedJob };
+          uppercaseIdJob.data.value.identity.transaction_identity.client_guid =
+            'ABC';
+
+          await processor.generateCdd(mockNetkiCompletedJob);
+
+          expect(mockRedis.getNetkiAddress).toHaveBeenCalledWith('abc');
+        });
+
         it('should throw if the address for the netki job is not found', async () => {
           mockRedis.getNetkiAddress.mockRejectedValue(new Error('some error'));
 

--- a/apps/cdd-backend/src/cdd-worker/cdd.processor.ts
+++ b/apps/cdd-backend/src/cdd-worker/cdd.processor.ts
@@ -45,10 +45,11 @@ export class CddProcessor {
   private async handleNetki({ value: netki }: NetkiCddJob): Promise<void> {
     const {
       identity: {
-        transaction_identity: { client_guid: id },
+        transaction_identity: { client_guid: guid },
         state,
       },
     } = netki;
+    const id = guid.toLowerCase(); // netki codes are supposed to be lower case + digits. Sometimes clients cause them to be capitalized though
     const jobId: JobIdentifier = { id, provider: 'netki' };
 
     this.logger.info('starting netki job', { jobId, state });


### PR DESCRIPTION
Netki says their code should always be lower case, but they don't prevent people from inputting in upper case:

> currently we don’t stop people from inputting their access codes in all uppercase and that client_guid field is just a straight capture of what is input from the app.  So this type of thing will happen if someone manually input

> choices = string.ascii_lowercase + string.digits is the list of possible choices when the codes are generated, so what’s stored in the DB for the code itself will always be lowercase

As such, it should be safe to cast the input to lower to avoid potential mismatches.