### PR TITLE
handle no new netki codes in a page

### DIFF
--- a/apps/cdd-backend/src/netki/netki.service.spec.ts
+++ b/apps/cdd-backend/src/netki/netki.service.spec.ts
@@ -137,6 +137,34 @@ describe('NetkiService', () => {
       ]);
     });
 
+    it('should not call redis if no new codes are added', async () => {
+      const mockResponse = {
+        data: {
+          results: [
+            {
+              id: '345',
+              code: 'def',
+              created: new Date().toISOString(),
+              parent_code: null,
+            },
+          ],
+        },
+      } as AxiosResponse;
+
+      jest.spyOn(mockHttp, 'get').mockImplementation(() => of(mockResponse));
+      jest
+        .spyOn(mockHttp, 'post')
+        .mockImplementation(() => of(mockAccessResponse));
+
+      mockRedis.getAllocatedNetkiCodes.mockResolvedValue(new Set(['def']));
+      mockRedis.pushNetkiCodes.mockResolvedValue(1);
+
+      const result = await service.fetchAccessCodes();
+
+      expect(result).toEqual({ added: 0, total: 2 });
+      expect(mockRedis.pushNetkiCodes).not.toHaveBeenCalled();
+    });
+
     it('should loop through all of the pages', async () => {
       const mockPageOne = {
         data: {

--- a/apps/cdd-backend/src/netki/netki.service.ts
+++ b/apps/cdd-backend/src/netki/netki.service.ts
@@ -153,8 +153,10 @@ export class NetkiService {
           isActive,
         }));
 
-      const codesAdded = await this.redis.pushNetkiCodes(newLinks);
-      added += codesAdded;
+      if (newLinks.length) {
+        const codesAdded = await this.redis.pushNetkiCodes(newLinks);
+        added += codesAdded;
+      }
 
       if (codeResponse.data.next) {
         url = codeResponse.data.next;


### PR DESCRIPTION
### Description

If we fetched an access code page and filtered all codes due to being in use, we would get an error from redis for trying to insert an empty array

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
